### PR TITLE
added suppressPanForEvent argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ function createPanZoom(domElement, options) {
   var beforeWheel = options.beforeWheel || noop
   var speed = typeof options.zoomSpeed === 'number' ? options.zoomSpeed : defaultZoomSpeed
 
+  var suppressPanForEvent = options.suppressPanForEvent
+
   validateBounds(bounds)
 
   if (options.autocenter) {
@@ -531,6 +533,16 @@ function createPanZoom(domElement, options) {
       e.stopPropagation()
       return false;
     }
+
+    // if suppress function is provided, pan will start only if it
+    // evaluates to false
+    if (suppressPanForEvent) {
+      if (suppressPanForEvent(e)) {
+        e.stopPropagation()
+        return false;
+      }
+    }
+
     // for IE, left click == 1
     // for Firefox, left click == 0
     var isLeftButton = ((e.button === 1 && window.event !== null) || e.button === 0)
@@ -565,9 +577,9 @@ function createPanZoom(domElement, options) {
   }
 
   function onMouseUp() {
+    releaseDocumentMouse()
     preventTextSelection.release()
     triggerPanEnd()
-    releaseDocumentMouse()
   }
 
   function releaseDocumentMouse() {


### PR DESCRIPTION
Hello anvaka,

I have been using this really awesome library to panzoom a DOM tree, it has fulfilled almost all of my needs perfectly. I however have some draggable elements on my page and I would like to suppress pan when a mousedown event happens on a draggable element, and handle the drag instead. I have made a minor change that lets me pass in a function that evaluates the event and decides whether to start the pan and it seems to work very well for me in all cases.

Another small issue that i had while using this with draggable elements is that when i drop an element, it sometimes resulted in mouseover being handled and pan happening again. I made a small reordering of the function calls in onmouseup to improve this (the number of times this would happen has reduced, but still happened once in around 50 tries of repeated dragging and panning).

Was wondering if you would be open to merging these changes back in to the repo or whether you have an idea for a better way to add this functionality.