### PR TITLE
Adjust ratio on min/maxZoom

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,9 +261,15 @@ function createPanZoom(domElement, options) {
 
     var newScale = transform.scale * ratio
 
-    if (newScale > maxZoom || newScale < minZoom) {
-      // outside of allowed bounds
-      return
+    if (newScale < minZoom) {
+      if (transform.scale === minZoom)
+        return;
+      ratio = minZoom / transform.scale
+    }
+    if (newScale > maxZoom) {
+      if (transform.scale === maxZoom)
+        return;
+      ratio = maxZoom / transform.scale
     }
 
     var parentScale = 1


### PR DESCRIPTION
in some cases (depending on the zoom step and zoom limits) the min/max
zoom value is never reached because the function is returning when the
new scale passes the limit.
resetting the ratio to reach min/max zoom values solves the issue