### PR TITLE
Pinch zoom enhacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ function createPanZoom(domElement, options) {
   var isDirty = false
   var transform = new Transform()
 
+  var realPinch = typeof options.realPinch === 'boolean' ? options.realPinch : false
   var bounds = options.bounds
   var maxZoom = typeof options.maxZoom === 'number' ? options.maxZoom : Number.POSITIVE_INFINITY
   var minZoom = typeof options.minZoom === 'number' ? options.minZoom : 0
@@ -474,14 +475,20 @@ function createPanZoom(domElement, options) {
       var t2 = e.touches[1]
       var currentPinchLength = getPinchZoomLength(t1, t2)
 
-      var delta = 0
-      if (currentPinchLength < pinchZoomLength) {
-        delta = 1
-      } else if (currentPinchLength > pinchZoomLength) {
-        delta = -1
-      }
+      var scaleMultiplier = 1;
 
-      var scaleMultiplier = getScaleMultiplier(delta)
+      if(realPinch){
+        scaleMultiplier = currentPinchLength / pinchZoomLength;
+      }else{
+        var delta = 0
+        if (currentPinchLength < pinchZoomLength) {
+          delta = 1
+        } else if (currentPinchLength > pinchZoomLength) {
+          delta = -1
+        }
+
+        scaleMultiplier = getScaleMultiplier(delta)
+      }
 
       mouseX = (t1.clientX + t2.clientX)/2
       mouseY = (t1.clientY + t2.clientY)/2

--- a/index.js
+++ b/index.js
@@ -513,8 +513,8 @@ function createPanZoom(domElement, options) {
   }
 
   function getPinchZoomLength(finger1, finger2) {
-    return (finger1.clientX - finger2.clientX) * (finger1.clientX - finger2.clientX) +
-      (finger1.clientY - finger2.clientY) * (finger1.clientY - finger2.clientY)
+    return Math.sqrt((finger1.clientX - finger2.clientX) * (finger1.clientX - finger2.clientX) +
+      (finger1.clientY - finger2.clientY) * (finger1.clientY - finger2.clientY))
   }
 
   function onDoubleClick(e) {


### PR DESCRIPTION
It would be better for pinch zoom to be scaled based on the length between fingers only, rather than depending on the speed value.

A new option was added **realPinch** defaults to **false** (to preserve compatibility with previous versions). when true the scale value will be calculated only from the distance between
fingers which will give an effect similar to image zoom on mobile phones. While pinch zooming, the points under the fingers stays fixed to the fingers.