### PR TITLE
Fix: Jump when keep-in-bounds option is active

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,8 +290,8 @@ function createPanZoom(domElement, options) {
     transform.x = x - ratio * (x - transform.x)
     transform.y = y - ratio * (y - transform.y)
 
-    var transformAdjusted = keepTransformInsideBounds()
-    if (!transformAdjusted) transform.scale *= ratio
+    keepTransformInsideBounds()
+    transform.scale *= ratio
 
     triggerEvent('zoom')
 


### PR DESCRIPTION
Bug fix: Jump in pan when zooming causes out-of-bounds adjustment. Only seems to happen when zooming near bottom of client rect.