### PR TITLE
Cancel smooth scroll on mouse down

### DIFF
--- a/index.js
+++ b/index.js
@@ -531,6 +531,7 @@ function createPanZoom(domElement, options) {
     mouseX = offset.x
     mouseY = offset.y
 
+    smoothScroll.cancel()
     startTouchListenerIfNeeded()
   }
 

--- a/index.js
+++ b/index.js
@@ -635,6 +635,8 @@ function createPanZoom(domElement, options) {
     var isLeftButton = ((e.button === 1 && window.event !== null) || e.button === 0)
     if (!isLeftButton) return
 
+    smoothScroll.cancel()
+
     var offset = getOffsetXY(e);
     var point = transformToScreen(offset.x, offset.y)
     mouseX = point.x


### PR DESCRIPTION
This fixes an issue where the user couldn't "grab" the canvas while the smooth scroll inertia was still moving it.