### PR TITLE
add zoomToCenter public API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ declare module "panzoom" {
     moveTo: (x: number, y: number) => void;
     centerOn: (ui: any) => void;
     zoomTo: (clientX: number, clientY: number, scaleMultiplier: number) => void;
+    zoomToCenter: (scaleMultiplier: number) => void;
     zoomAbs: (clientX: number, clientY: number, zoomLevel: number) => void;
     smoothZoom: (
       clientX: number,

--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ function createPanZoom(domElement, options) {
     moveTo: moveTo,
     centerOn: centerOn,
     zoomTo: publicZoomTo,
+    zoomToCenter: zoomToCenter,
     zoomAbs: zoomAbs,
     smoothZoom: smoothZoom,
     getTransform: getTransformModel,
@@ -739,6 +740,17 @@ function createPanZoom(domElement, options) {
       smoothScroll.cancel()
       cancelZoomAnimation()
       return zoomByRatio(clientX, clientY, scaleMultiplier)
+  }
+
+  /**
+   * Zooms to the center of the container
+   * @param {Number} scaleMultiplier 0.8 = zoom out by 20% and 1.2 = zoom in by 20%
+   */
+  function zoomToCenter(scaleMultiplier) {
+    const containerRect = owner.getBoundingClientRect()
+    const centerX = containerRect.width / 2
+    const centerY = containerRect.height / 2
+    return zoomByRatio(centerX, centerY, scaleMultiplier)
   }
 
   function cancelZoomAnimation() {


### PR DESCRIPTION
Adds a zoomToCenter function

- `zoomToCenter(1.2)` Zooms in by 20%
- `zoomToCenter(0.8)` Zooms out by 20%

I wanted more granular control than using the delta -1 or +1 and comparing by zoomSpeed. Especially if using this with a + or - button to zoom it makes sense to have it defined like this.