### PR TITLE
Add option to disable text selection prevention

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare module "panzoom" {
     onDoubleClick?: (e: Event) => void;
     smoothScroll?: boolean;
     controller?: SVGElement | HTMLElement;
+    disableTextSelectionPrevention?: boolean;
   }
 
   export interface PanZoom {

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare module "panzoom" {
     onDoubleClick?: (e: Event) => void;
     smoothScroll?: boolean;
     controller?: SVGElement | HTMLElement;
-    disableTextSelectionPrevention?: boolean;
+    enableTextSelection?: boolean;
   }
 
   export interface PanZoom {

--- a/index.js
+++ b/index.js
@@ -660,9 +660,10 @@ function createPanZoom(domElement, options) {
     // window, and we will loose it
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-
-    preventTextSelection.capture(e.target || e.srcElement)
-
+    
+    if (!options.disableTextSelectionPrevention) {
+      preventTextSelection.capture(e.target || e.srcElement)
+    }
     return false
   }
 
@@ -684,7 +685,9 @@ function createPanZoom(domElement, options) {
   }
 
   function onMouseUp() {
-    preventTextSelection.release()
+    if (!options.disableTextSelectionPrevention) {
+      preventTextSelection.release()
+    }
     triggerPanEnd()
     releaseDocumentMouse()
   }

--- a/index.js
+++ b/index.js
@@ -661,7 +661,7 @@ function createPanZoom(domElement, options) {
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
     
-    if (!options.disableTextSelectionPrevention) {
+    if (!options.enableTextSelection) {
       preventTextSelection.capture(e.target || e.srcElement)
     }
     return false
@@ -685,7 +685,7 @@ function createPanZoom(domElement, options) {
   }
 
   function onMouseUp() {
-    if (!options.disableTextSelectionPrevention) {
+    if (!options.enableTextSelection) {
       preventTextSelection.release()
     }
     triggerPanEnd()


### PR DESCRIPTION
Hi,
The default behavior is that panzoom disable text selection inside the panned component.
This means you cannot focus input inside the component.

I added an option to remove this default behavior.