### PR TITLE
Round transform coordinates to avoid blurry lines in svg

### DIFF
--- a/lib/svgController.js
+++ b/lib/svgController.js
@@ -61,6 +61,9 @@ function makeSvgController(svgElement, options) {
   }
 
   function applyTransform(transform) {
+    transform.scale = Math.round((transform.scale + Number.EPSILON) * 500) / 500;
+    transform.x = Math.round(transform.x);
+    transform.y = Math.round(transform.y);
     svgElement.setAttribute('transform', 'matrix(' +
       transform.scale + ' 0 0 ' +
       transform.scale + ' ' +


### PR DESCRIPTION
Before this patch you get the following matrix when zooming to 100%:

`matrix(0.9991895111944822 0 0 0.9991895111944822 115 -1719)`

That produces in SVG very blurry lines. After this patch the following matrix is produced:

`matrix(1 0 0 1 115 -1736)`

Which makes everything crystal  clear. A rounding range of 500 is chosen for `scale` to get smooth animations while also getting integers when zooming to 100%. Movement operations would also produce floating x and y coordinates, which would also lead to a blurry image. This patch fixes that as well.
Before:

![Screenshot 2020-02-17 at 02 17 27](https://user-images.githubusercontent.com/450980/74617074-a90f0980-512b-11ea-9d37-4d0da7778812.png)
After:
![Screenshot 2020-02-17 at 02 17 39](https://user-images.githubusercontent.com/450980/74617077-ae6c5400-512b-11ea-9831-f0418990e600.png)
