### PR TITLE
Improve the accuracy of the docs for beforeMouseDown

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ zoomable only when `Alt` key is down.
 ## Ignore mouse down
 
 If you want to disable panning or filter it by pressing a specific key, use the
-`beforeMouseDown()` option. E.g.
+`beforeMouseDown()` option. Note that it only works when the mouse initiates
+the panning. E.g.
 
 ``` js
 panzoom(element, {


### PR DESCRIPTION
There was a bug in an application I was working on where I used beforeMouseDown to disable panning and it was very hard to debug why it still panned using touch. This change will allow users to know exactly what beforeMouseDown does. Evidence that it doesn't disable panning using touch located in this fiddle: https://jsfiddle.net/thg2brxe/.