### PR TITLE
fix(index.js): trigger zoomend on end of smoothScrollAbs

### DIFF
--- a/index.js
+++ b/index.js
@@ -906,7 +906,8 @@ function createPanZoom(domElement, options) {
     zoomToAnimation = animate(from, to, {
       step: function (v) {
         zoomAbs(clientX, clientY, v.scale);
-      }
+      },
+      done: triggerZoomEnd
     });
   }
 


### PR DESCRIPTION
# Describe
Fixing problem of `zoomend` not triggered when smoothScrollAbs is ending.

# Tests
No tests on smooth comportment so nothing to add

# Links
https://github.com/anvaka/panzoom/issues/289