### PR TITLE
Spelling mistake in README: `panZoom`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ let bottomRight = {x: 1, y: 1};
 let centerCenter = {x: 0.5, y: 0.5};
 
 // now let's use it:
-panZoom(element, {
+panzoom(element, {
   transformOrigin: centerCenter
 });
 ```


### PR DESCRIPTION
Correct me but I think there is no function  `panZoom`, so there should probably be `panzoom` instead. 