### PR TITLE
feat: support initial transform

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ declare module "panzoom" {
     initialX?: number,
     initialY?: number,
     initialZoom?: number,
+    initialTransform?: Transform;
     pinchSpeed?: number;
     beforeWheel?: (e: WheelEvent) => void;
     beforeMouseDown?: (e: MouseEvent) => void;

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function createPanZoom(domElement, options) {
   var storedCTMResult = { x: 0, y: 0 };
 
   var isDirty = false;
-  var transform = new Transform();
+  var transform = new Transform(options.initialTransform);
 
   if (panController.initTransform) {
     panController.initTransform(transform);

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,6 +1,12 @@
 module.exports = Transform;
 
-function Transform() {
+function Transform(initial = {}) {
+  if (typeof initial.x === 'number' && typeof initial.y === 'number' && typeof initial.scale === 'number') {
+    this.x = initial.x;
+    this.y = initial.y;
+    this.scale = initial.scale;
+    return;
+  }
   this.x = 0;
   this.y = 0;
   this.scale = 1;


### PR DESCRIPTION
## what
Support `initialTransform` options, used to restore the value returned by the `transform` event

## why not use `initialX initialY initialZoom`
1. `initialX initialY initialZoom` is not corresponding to the value returned by the `transform` event, we need complicated conversion to match `initial values` with `transform result` . my old resolution is to combine `initialZoom` and `moveTo`，which is ugly
2. `initialX initialY initialZoom` will cause an extra transform