### PR TITLE
ngraph.event package version issue fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  */
 var wheel = require('wheel');
 var animate = require('amator');
-var eventify = require('ngraph.events');
+var eventify = require('ngraph.events').default;
 var kinetic = require('./lib/kinetic.js');
 var createTextSelectionInterceptor = require('./lib/makeTextSelectionInterceptor.js');
 var domTextSelectionInterceptor = createTextSelectionInterceptor();


### PR DESCRIPTION
panzoom uses "ngraph.events" package with the version "^1.2.2", but in their newer release, we need to change the way to import eventify funciton from ngraph.events. If not fixed the createPanzoom method throws error.

