### PR TITLE
Set pinchZoomLength to currentPinchLength if undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function createPanZoom(domElement, options) {
     dispose: dispose,
     moveBy: internalMoveBy,
     moveTo: moveTo,
-    smoothMoveTo: smoothMoveTo, 
+    smoothMoveTo: smoothMoveTo,
     centerOn: centerOn,
     zoomTo: publicZoomTo,
     zoomAbs: zoomAbs,
@@ -150,7 +150,7 @@ function createPanZoom(domElement, options) {
   };
 
   eventify(api);
-  
+
   var initialX = typeof options.initialX === 'number' ? options.initialX : transform.x;
   var initialY = typeof options.initialY === 'number' ? options.initialY : transform.y;
   var initialZoom = typeof options.initialZoom === 'number' ? options.initialZoom : transform.scale;
@@ -680,6 +680,15 @@ function createPanZoom(domElement, options) {
       var t2 = e.touches[1];
       var currentPinchLength = getPinchZoomLength(t1, t2);
 
+      // A two-finger `touchmove` can reach this document-level handler without a
+      // preceding two-finger `touchstart` on the element having set
+      // `pinchZoomLength` (notably on iOS Safari when the element is re-rendered
+      // mid-gesture).
+      // Seed it from the current frame so the first move is a no-op.
+      if (pinchZoomLength === undefined) {
+        pinchZoomLength = currentPinchLength;
+      }
+
       // since the zoom speed is always based on distance from 1, we need to apply
       // pinch speed only on that distance from 1:
       var scaleMultiplier =
@@ -1099,4 +1108,3 @@ function autoRun() {
 }
 
 autoRun();
-	

--- a/index.js
+++ b/index.js
@@ -683,8 +683,7 @@ function createPanZoom(domElement, options) {
       // A two-finger `touchmove` can reach this document-level handler without a
       // preceding two-finger `touchstart` on the element having set
       // `pinchZoomLength` (notably on iOS Safari when the element is re-rendered
-      // mid-gesture).
-      // Seed it from the current frame so the first move is a no-op.
+      // mid-gesture). Seed it from the current frame so the first move is a no-op.
       if (pinchZoomLength === undefined) {
         pinchZoomLength = currentPinchLength;
       }
@@ -704,9 +703,23 @@ function createPanZoom(domElement, options) {
         mouseY = offset.y;
       }
 
-      publicZoomTo(mouseX, mouseY, scaleMultiplier);
+      // Only zoom when every value is a finite number.
+      // Touch points or the owner rect can resolve to NaN
+      // (malformed/synthetic touch events, degenerate layout),
+      // which would otherwise make `zoomByRatio` throw "zoom requires valid
+      // numbers". Bail out of the frame instead of throwing.
+      if (
+        Number.isFinite(mouseX) &&
+        Number.isFinite(mouseY) &&
+        Number.isFinite(scaleMultiplier)
+      ) {
+        publicZoomTo(mouseX, mouseY, scaleMultiplier);
+      }
 
-      pinchZoomLength = currentPinchLength;
+      // Avoid poisoning the next frame with a NaN baseline.
+      if (Number.isFinite(currentPinchLength)) {
+        pinchZoomLength = currentPinchLength;
+      }
       e.stopPropagation();
       e.preventDefault();
     }


### PR DESCRIPTION
A two-finger touchmove can reach the document-level handler without a preceding two-finger touchstart having set pinchZoomLength (notably on iOS Safari when the panned element is re-rendered mid-gesture). 
The resulting NaN scaleMultiplier made zoomByRatio throw 'zoom requires valid numbers'.

Seed pinchZoomLength from the current frame so the first move is a no-op.

Moreover, we set a protection so that we only zoom when every value is a finite number.
In deed, touch points or the owner rect can resolve to NaN (malformed/synthetic touch events, degenerate layout), which would otherwise make `zoomByRatio` throw "zoom requires valid numbers". Bail out of the frame instead of throwing.
In this case we also avoid poisoning the next frame with a NaN baseline.